### PR TITLE
providing backward compatibility based on kernel versions for poll function of proto_ops struct

### DIFF
--- a/homa_impl.h
+++ b/homa_impl.h
@@ -22,6 +22,10 @@
 
 #include "homa.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,16,0)
+typedef unsigned int __poll_t;
+#endif
+
 #ifdef __UNIT_TEST__
 #define spin_unlock mock_spin_unlock
 extern void mock_spin_unlock(spinlock_t *lock);
@@ -874,13 +878,8 @@ extern struct homa_peer
 			struct inet_sock *inet);
 extern int      homa_pkt_dispatch(struct sock *sk, struct sk_buff *skb);
 extern int      homa_pkt_recv(struct sk_buff *skb);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0)
 extern __poll_t homa_poll(struct file *file, struct socket *sock,
 			struct poll_table_struct *wait);
-#else
-extern unsigned int homa_poll(struct file *file, struct socket *sock,
-                          struct poll_table_struct *wait);
-#endif
 extern char    *homa_print_ipv4_addr(__be32 addr, char *buffer);
 extern char    *homa_print_metrics(struct homa *homa);
 extern char    *homa_print_packet(struct sk_buff *skb, char *buffer, int length);

--- a/homa_impl.h
+++ b/homa_impl.h
@@ -14,6 +14,7 @@
 #include <linux/proc_fs.h>
 #include <linux/sched/signal.h>
 #include <linux/skbuff.h>
+#include <linux/version.h>
 #include <linux/socket.h>
 #include <net/ip.h>
 #include <net/protocol.h>
@@ -873,8 +874,13 @@ extern struct homa_peer
 			struct inet_sock *inet);
 extern int      homa_pkt_dispatch(struct sock *sk, struct sk_buff *skb);
 extern int      homa_pkt_recv(struct sk_buff *skb);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0)
 extern __poll_t homa_poll(struct file *file, struct socket *sock,
 			struct poll_table_struct *wait);
+#else
+extern unsigned int homa_poll(struct file *file, struct socket *sock,
+                          struct poll_table_struct *wait);
+#endif
 extern char    *homa_print_ipv4_addr(__be32 addr, char *buffer);
 extern char    *homa_print_metrics(struct homa *homa);
 extern char    *homa_print_packet(struct sk_buff *skb, char *buffer, int length);

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -763,13 +763,8 @@ void homa_err_handler(struct sk_buff *skb, u32 info) {
  * @wait:  ??
  * Return: ??
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0)
 __poll_t homa_poll(struct file *file, struct socket *sock,
 	       struct poll_table_struct *wait) {
-#else
-unsigned int homa_poll(struct file *file, struct socket *sock,
-				   struct poll_table_struct *wait) {
-#endif
 	printk(KERN_WARNING "unimplemented poll invoked on Homa socket\n");
 	return 0;
 }

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -763,8 +763,13 @@ void homa_err_handler(struct sk_buff *skb, u32 info) {
  * @wait:  ??
  * Return: ??
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0)
 __poll_t homa_poll(struct file *file, struct socket *sock,
 	       struct poll_table_struct *wait) {
+#else
+unsigned int homa_poll(struct file *file, struct socket *sock,
+				   struct poll_table_struct *wait) {
+#endif
 	printk(KERN_WARNING "unimplemented poll invoked on Homa socket\n");
 	return 0;
 }


### PR DESCRIPTION
Hi,

I tried to make the code backward compatible for older kernel versions with some slight changes as we talked in the issue #1 . You may merge this request if it doesn't have any code style violations.

It seems that the ```__poll_t``` came from ```4.16.0``` Linux version, so I opt to hardcode it there. 

Thanks,
Alireza