### PR TITLE
New api2

### DIFF
--- a/homa.h
+++ b/homa.h
@@ -95,12 +95,12 @@ struct homa_send_args {
 	 */
 	uint64_t completion_cookie;
 
-	uint64_t _pad[2];
+	uint64_t _pad[7];
 };
 
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_send_args) >= 88, "homa_send_args shrunk");
-_Static_assert(sizeof(struct homa_send_args) <= 88, "homa_send_args grew");
+_Static_assert(sizeof(struct homa_send_args) >= 128, "homa_send_args shrunk");
+_Static_assert(sizeof(struct homa_send_args) <= 128, "homa_send_args grew");
 #endif
 
 #define HOMA_SEND_VALID_FLAGS 0
@@ -152,11 +152,11 @@ struct homa_recv_args {
 	 */
 	uint64_t completion_cookie;
 
-	uint64_t _pad[2];
+	uint64_t _pad[7];
 };
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_recv_args) >= 88, "homa_recv_args shrunk");
-_Static_assert(sizeof(struct homa_recv_args) <= 88, "homa_recv_args grew");
+_Static_assert(sizeof(struct homa_recv_args) >= 128, "homa_recv_args shrunk");
+_Static_assert(sizeof(struct homa_recv_args) <= 128, "homa_recv_args grew");
 #endif
 
 /* Flag bits for homa_recv (see man page for documentation):
@@ -198,13 +198,13 @@ struct homa_reply_args {
 
 	/** @id: Identifier of the RPC to respond to. */
 	uint64_t id;
-	//uint64_t completion_cookie;
+	uint64_t completion_cookie;
 
-	uint64_t _pad[2];
+	uint64_t _pad[7];
 };
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_reply_args) >= 80, "homa_reply_args shrunk");
-_Static_assert(sizeof(struct homa_reply_args) <= 80, "homa_reply_args grew");
+_Static_assert(sizeof(struct homa_reply_args) >= 128, "homa_reply_args shrunk");
+_Static_assert(sizeof(struct homa_reply_args) <= 128, "homa_reply_args grew");
 #endif
 
 #define HOMA_REPLY_VALID_FLAGS 0

--- a/homa.h
+++ b/homa.h
@@ -216,7 +216,8 @@ struct homa_abort_args {
 	 */
 	int error;
 
-	uint64_t _pad[2];
+	int _pad1;
+	uint64_t _pad2[2];
 };
 #if !defined(__cplusplus)
 _Static_assert(sizeof(struct homa_abort_args) >= 32, "homa_abort_args shrunk");

--- a/homa.h
+++ b/homa.h
@@ -55,9 +55,9 @@ extern "C"
  * sockaddr_storage).
  */
 typedef union sockaddr_in_union {
-        struct sockaddr sa;
-        struct sockaddr_in in4;
-        struct sockaddr_in6 in6;
+	struct sockaddr sa;
+	struct sockaddr_in in4;
+	struct sockaddr_in6 in6;
 } sockaddr_in_union;
 
 /**
@@ -66,22 +66,22 @@ typedef union sockaddr_in_union {
  */
 struct homa_send_args {
 	/** @message_buf: First byte of outgoing message. */
-        void *message_buf;
+	void *message_buf;
 
 	/**
 	 * @iovec: Describes outgoing message in multiple disjoint pieces.
 	 * Exactly one of this or @message_buf must be non-null.
 	 */
-        const struct iovec *iovec;
+	const struct iovec *iovec;
 
-        /**
+	/**
 	 * @length: The number of bytes at *request, or the number of elements
 	 * at *iovec.
 	 */
-        size_t length;
+	size_t length;
 
 	/** @dest_addr: Address of server to which request will be sent. */
-        sockaddr_in_union dest_addr;
+	sockaddr_in_union dest_addr;
 
 	uint32_t _pad1;
 
@@ -90,12 +90,12 @@ struct homa_send_args {
 	 * RPC completes. Typically used by locate app-specific info
 	 * about the RPC.
 	 */
-        uint64_t completion_cookie;
+	uint64_t completion_cookie;
 
 	/** @id: The identifier for the new RPC is returned here. */
-        uint64_t id;
+	uint64_t id;
 
-        uint64_t _pad2[2];
+	uint64_t _pad2[2];
 };
 #if !defined(__cplusplus)
 _Static_assert(sizeof(struct homa_send_args) >= 88, "homa_send_args shrunk");
@@ -112,34 +112,34 @@ _Static_assert(sizeof(struct homa_send_args) <= 88, "homa_send_args grew");
  */
 struct homa_recv_args {
 	/** @message_buf: Where to store incoming message. */
-        void *message_buf;
+	void *message_buf;
 
 	/**
 	 * @iovec: Describes store message in multiple disjoint pieces.
 	 * Exactly one of this or @message_buf must be non-null.
 	 */
-        const struct iovec *iovec;
+	const struct iovec *iovec;
 
 	/**
 	 * @length: Initially holds length of @buf or @iovec; modified to
 	 * return total message length.
 	 */
-        size_t length;
+	size_t length;
 
 	/** @source_addr: Address of the sender of the message. */
-        sockaddr_in_union source_addr;
+	sockaddr_in_union source_addr;
 
 	/**
 	 * @flags: OR-ed combination of bits that control the operation.
 	 * see the man page for details.
 	 */
-        int flags;
+	int flags;
 
 	/**
 	 * @id: Initially specifies the id of the desired RPC, or 0 if
 	 * any RPC is OK; used to return the actual id received.
 	 */
-        uint64_t id;
+	uint64_t id;
 
 	/**
 	 * @completion_cookie: If the incoming message is a response,
@@ -147,9 +147,9 @@ struct homa_recv_args {
 	 * request was sent. For incoming requests, this will always
 	 * be zero.
 	 */
-        uint64_t completion_cookie;
+	uint64_t completion_cookie;
 
-        uint64_t _pad[2];
+	uint64_t _pad[2];
 };
 #if !defined(__cplusplus)
 _Static_assert(sizeof(struct homa_recv_args) >= 88, "homa_recv_args shrunk");
@@ -173,29 +173,29 @@ _Static_assert(sizeof(struct homa_recv_args) <= 88, "homa_recv_args grew");
  */
 struct homa_reply_args {
 	/** @message_buf: Where to store incoming message. */
-        void *message_buf;
+	void *message_buf;
 
 	/**
 	 * @iovec: Describes store message in multiple disjoint pieces.
 	 * Exactly one of this or @message_buf must be non-null.
 	 */
-        const struct iovec *iovec;
+	const struct iovec *iovec;
 
 	/**
 	 * @length: Initially holds length of @buf or @iovec; modified to
 	 * return total message length.
 	 */
-        size_t length;
+	size_t length;
 
 	/** @dest_addr: Address of client to which response will be sent. */
-        sockaddr_in_union dest_addr;
+	sockaddr_in_union dest_addr;
 
 	uint32_t _pad1;
 
 	/** @id: Identifier of the RPC to respond to. */
-        uint64_t id;
+	uint64_t id;
 
-        uint64_t _pad2[2];
+	uint64_t _pad2[2];
 };
 #if !defined(__cplusplus)
 _Static_assert(sizeof(struct homa_reply_args) >= 80, "homa_reply_args shrunk");
@@ -208,7 +208,7 @@ _Static_assert(sizeof(struct homa_reply_args) <= 80, "homa_reply_args grew");
  */
 struct homa_abort_args {
 	/** @id: Id of RPC to abort, or zero to abort all RPCs on socket. */
-        uint64_t id;
+	uint64_t id;
 
 	/**
 	 * @error: Zero means destroy and free RPCs; nonzero means complete
@@ -216,7 +216,7 @@ struct homa_abort_args {
 	 */
 	int error;
 
-        uint64_t _pad[2];
+	uint64_t _pad[2];
 };
 #if !defined(__cplusplus)
 _Static_assert(sizeof(struct homa_abort_args) >= 32, "homa_abort_args shrunk");
@@ -251,24 +251,24 @@ extern ssize_t homa_sendp(int fd, struct homa_send_args *args);
 extern int     homa_abortp(int fd, struct homa_abort_args *args);
 
 extern int     homa_send(int sockfd, const void *message_buf,
-		    size_t reqlen, const sockaddr_in_union *dest_addr,
-		    uint64_t *id, uint64_t completion_cookie);
+		size_t reqlen, const sockaddr_in_union *dest_addr,
+		uint64_t *id, uint64_t completion_cookie);
 extern int     homa_sendv(int sockfd, const struct iovec *iov,
-                    int iovcnt, const sockaddr_in_union *dest_addr,
-                    uint64_t *id, uint64_t completion_cookie);
+		int iovcnt, const sockaddr_in_union *dest_addr,
+		uint64_t *id, uint64_t completion_cookie);
 extern ssize_t homa_recv(int sockfd, void *message_buf, size_t length,
-		    int flags, sockaddr_in_union *src_addr, uint64_t *id,
-                    size_t *msglen, uint64_t *completion_cookie_p);
+		int flags, sockaddr_in_union *src_addr, uint64_t *id,
+		size_t *msglen, uint64_t *completion_cookie_p);
 extern ssize_t homa_recvv(int sockfd, const struct iovec *iov,
-                    int iovcnt, int flags, sockaddr_in_union *src_addr,
-                    uint64_t *id, size_t *msglen,
-                    uint64_t *completion_cookie_p);
+		int iovcnt, int flags, sockaddr_in_union *src_addr,
+		uint64_t *id, size_t *msglen,
+		uint64_t *completion_cookie_p);
 extern ssize_t homa_reply(int sockfd, const void *message_buf,
-                    size_t length, const sockaddr_in_union *dest_addr,
-                    uint64_t id);
+		size_t length, const sockaddr_in_union *dest_addr,
+		uint64_t id);
 extern ssize_t homa_replyv(int sockfd, const struct iovec *iov,
-                    int iovcnt, const sockaddr_in_union *dest_addr,
-                    uint64_t id);
+		int iovcnt, const sockaddr_in_union *dest_addr,
+		uint64_t id);
 extern int     homa_abort(int sockfd, uint64_t id, int error);
 
 #ifdef __cplusplus

--- a/homa.h
+++ b/homa.h
@@ -252,6 +252,9 @@ _Static_assert(sizeof(struct homa_abort_args) <= 32, "homa_abort_args grew");
 #define HOMAIOCREPLY  _IOWR(0x89, 0xe2, struct homa_reply_args)
 #define HOMAIOCABORT  _IOWR(0x89, 0xe3, struct homa_abort_args)
 #define HOMAIOCFREEZE _IO(0x89, 0xef)
+#define HOMAIOCSEND_BENCH   _IOWR(0x89, 0xe4, struct homa_send_args)
+#define HOMAIOCRECV_BENCH   _IOWR(0x89, 0xe5, struct homa_recv_args)
+#define HOMAIOCREPLY_BENCH  _IOWR(0x89, 0xe6, struct homa_reply_args)
 
 extern ssize_t homa_recvp(int fd, struct homa_recv_args *args);
 extern ssize_t homa_replyp(int fd, struct homa_reply_args *args);

--- a/homa.h
+++ b/homa.h
@@ -95,12 +95,12 @@ struct homa_send_args {
 	 */
 	uint64_t completion_cookie;
 
-	uint64_t _pad[7];
+	uint64_t _pad[2];
 };
 
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_send_args) >= 128, "homa_send_args shrunk");
-_Static_assert(sizeof(struct homa_send_args) <= 128, "homa_send_args grew");
+_Static_assert(sizeof(struct homa_send_args) >= 88, "homa_send_args shrunk");
+_Static_assert(sizeof(struct homa_send_args) <= 88, "homa_send_args grew");
 #endif
 
 #define HOMA_SEND_VALID_FLAGS 0
@@ -152,11 +152,11 @@ struct homa_recv_args {
 	 */
 	uint64_t completion_cookie;
 
-	uint64_t _pad[7];
+	uint64_t _pad[2];
 };
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_recv_args) >= 128, "homa_recv_args shrunk");
-_Static_assert(sizeof(struct homa_recv_args) <= 128, "homa_recv_args grew");
+_Static_assert(sizeof(struct homa_recv_args) >= 88, "homa_recv_args shrunk");
+_Static_assert(sizeof(struct homa_recv_args) <= 88, "homa_recv_args grew");
 #endif
 
 /* Flag bits for homa_recv (see man page for documentation):
@@ -198,13 +198,13 @@ struct homa_reply_args {
 
 	/** @id: Identifier of the RPC to respond to. */
 	uint64_t id;
-	uint64_t completion_cookie;
+	//uint64_t completion_cookie;
 
-	uint64_t _pad[7];
+	uint64_t _pad[2];
 };
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_reply_args) >= 128, "homa_reply_args shrunk");
-_Static_assert(sizeof(struct homa_reply_args) <= 128, "homa_reply_args grew");
+_Static_assert(sizeof(struct homa_reply_args) >= 80, "homa_reply_args shrunk");
+_Static_assert(sizeof(struct homa_reply_args) <= 80, "homa_reply_args grew");
 #endif
 
 #define HOMA_REPLY_VALID_FLAGS 0

--- a/homa.h
+++ b/homa.h
@@ -83,24 +83,27 @@ struct homa_send_args {
 	/** @dest_addr: Address of server to which request will be sent. */
 	sockaddr_in_union dest_addr;
 
-	uint32_t _pad1;
-
-	/**
-	 * @completion_cookie: Will be returned by homa_recv when the
-	 * RPC completes. Typically used by locate app-specific info
-	 * about the RPC.
-	 */
-	uint64_t completion_cookie;
+	uint32_t flags;
 
 	/** @id: The identifier for the new RPC is returned here. */
 	uint64_t id;
 
-	uint64_t _pad2[2];
+	/**
+	 * @completion_cookie: Will be returned by homa_recv when the
+	 * RPC completes. Typically used to locate app-specific info
+	 * about the RPC.
+	 */
+	uint64_t completion_cookie;
+
+	uint64_t _pad[7];
 };
+
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_send_args) >= 88, "homa_send_args shrunk");
-_Static_assert(sizeof(struct homa_send_args) <= 88, "homa_send_args grew");
+_Static_assert(sizeof(struct homa_send_args) >= 128, "homa_send_args shrunk");
+_Static_assert(sizeof(struct homa_send_args) <= 128, "homa_send_args grew");
 #endif
+
+#define HOMA_SEND_VALID_FLAGS 0
 
 /**
  * define homa_recv_args - Used to pass arguments and results between
@@ -149,11 +152,11 @@ struct homa_recv_args {
 	 */
 	uint64_t completion_cookie;
 
-	uint64_t _pad[2];
+	uint64_t _pad[7];
 };
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_recv_args) >= 88, "homa_recv_args shrunk");
-_Static_assert(sizeof(struct homa_recv_args) <= 88, "homa_recv_args grew");
+_Static_assert(sizeof(struct homa_recv_args) >= 128, "homa_recv_args shrunk");
+_Static_assert(sizeof(struct homa_recv_args) <= 128, "homa_recv_args grew");
 #endif
 
 /* Flag bits for homa_recv (see man page for documentation):
@@ -162,6 +165,7 @@ _Static_assert(sizeof(struct homa_recv_args) <= 88, "homa_recv_args grew");
 #define HOMA_RECV_RESPONSE      0x02
 #define HOMA_RECV_NONBLOCKING   0x04
 #define HOMA_RECV_PARTIAL       0x08
+#define HOMA_RECV_VALID_FLAGS   0x0F
 
 /**
  * define homa_reply_args - Structure that passes arguments and results
@@ -190,17 +194,20 @@ struct homa_reply_args {
 	/** @dest_addr: Address of client to which response will be sent. */
 	sockaddr_in_union dest_addr;
 
-	uint32_t _pad1;
+	uint32_t flags;
 
 	/** @id: Identifier of the RPC to respond to. */
 	uint64_t id;
+	uint64_t completion_cookie;
 
-	uint64_t _pad2[2];
+	uint64_t _pad[7];
 };
 #if !defined(__cplusplus)
-_Static_assert(sizeof(struct homa_reply_args) >= 80, "homa_reply_args shrunk");
-_Static_assert(sizeof(struct homa_reply_args) <= 80, "homa_reply_args grew");
+_Static_assert(sizeof(struct homa_reply_args) >= 128, "homa_reply_args shrunk");
+_Static_assert(sizeof(struct homa_reply_args) <= 128, "homa_reply_args grew");
 #endif
+
+#define HOMA_REPLY_VALID_FLAGS 0
 
 /**
  * define homa_args_abort - Structure that passes arguments and results

--- a/homa.h
+++ b/homa.h
@@ -203,7 +203,7 @@ _Static_assert(sizeof(struct homa_reply_args) <= 80, "homa_reply_args grew");
 #endif
 
 /**
- * define homa_args_abort_ipv4 - Structure that passes arguments and results
+ * define homa_args_abort - Structure that passes arguments and results
  * between user space and the HOMAIOCABORT ioctl.
  */
 struct homa_abort_args {

--- a/homa_api.c
+++ b/homa_api.c
@@ -115,7 +115,7 @@ ssize_t homa_recv(int sockfd, void *buf, size_t length, int flags,
 	args.source_addr = *src_addr;
 	args.flags = flags;
 	args.id = *id;
-	result = ioctl(sockfd, HOMAIOCRECV, &args);
+	result = homa_recvp(sockfd, &args);
 	*src_addr = args.source_addr;
 	*id = args.id;
 	if (msglen) {
@@ -171,7 +171,7 @@ ssize_t homa_recvv(int sockfd, const struct iovec *iov, int iovcnt, int flags,
 	args.source_addr = *src_addr;
 	args.flags = flags;
 	args.id = *id;
-	result = ioctl(sockfd, HOMAIOCRECV, &args);
+	result = homa_recvp(sockfd, &args);
 	*src_addr = args.source_addr;
 	*id = args.id;
 	if (msglen) {
@@ -216,7 +216,7 @@ ssize_t homa_reply(int sockfd, const void *message_buf, size_t length,
 	args.length = length;
 	args.dest_addr = *dest_addr;
 	args.id = id;
-	return ioctl(sockfd, HOMAIOCREPLY, &args);
+	return homa_replyp(sockfd, &args);
 }
 
 /**
@@ -247,7 +247,7 @@ ssize_t homa_replyv(int sockfd, const struct iovec *iov, int iovcnt,
 	args.length = iovcnt;
 	args.dest_addr = *dest_addr;
 	args.id = id;
-	return ioctl(sockfd, HOMAIOCREPLY, &args);
+	return homa_replyp(sockfd, &args);
 }
 
 /**
@@ -277,7 +277,7 @@ int homa_send(int sockfd, const void *request, size_t reqlen,
 	args.dest_addr = *dest_addr;
 	args.id = 0;
 	args.completion_cookie = completion_cookie;
-	result = ioctl(sockfd, HOMAIOCSEND, &args);;
+	result = homa_sendp(sockfd, &args);
 	if ((result >= 0) && (id != NULL))
 		*id = args.id;
 	return result;
@@ -312,7 +312,7 @@ int homa_sendv(int sockfd, const struct iovec *iov, int iovcnt,
 	args.dest_addr = *dest_addr;
 	args.id = 0;
 	args.completion_cookie = completion_cookie;
-	result = ioctl(sockfd, HOMAIOCSEND, &args);;
+	result = homa_sendp(sockfd, &args);
 	if ((result >= 0) && (id != NULL))
 		*id = args.id;
 	return result;

--- a/homa_api.c
+++ b/homa_api.c
@@ -64,7 +64,7 @@ ssize_t homa_replyp(int sockfd, struct homa_reply_args *args) {
  *              error occurred, -1 is returned and errno is set appropriately.
  */
 ssize_t homa_sendp(int sockfd, struct homa_send_args *args) {
-	return ioctl(sockfd, HOMAIOCSEND, args);
+	return ioctl(sockfd, HOMAIOCSEND_BENCH, args);
 }
 
 /**

--- a/homa_ioctl_bench.c
+++ b/homa_ioctl_bench.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include "homa.h"
+
+// gcc homa_ioctl_bench.c homa_api.c -o homa_ioctl_bench && time ./homa_ioctl_bench
+
+int main(int argc, char *argv[], char *envp[])
+{
+	int homa_sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
+	char buf[999999];
+	sockaddr_in_union addr = {};
+	uint64_t id;
+
+	errno = 0;
+	for(int i = 0; i < 100000000; i++) {
+		homa_send(homa_sockfd, buf, sizeof(buf), &addr, &id, 0);
+		if (errno) {
+			perror("homa_send");
+			return 1;
+		}
+	}
+}

--- a/homa_ioctl_bench.c
+++ b/homa_ioctl_bench.c
@@ -8,7 +8,7 @@
 int main(int argc, char *argv[], char *envp[])
 {
 	int homa_sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
-	char buf[1];
+	char buf[999999];
 	sockaddr_in_union addr = {};
 	uint64_t id;
 

--- a/homa_ioctl_bench.c
+++ b/homa_ioctl_bench.c
@@ -8,7 +8,7 @@
 int main(int argc, char *argv[], char *envp[])
 {
 	int homa_sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_HOMA);
-	char buf[999999];
+	char buf[1];
 	sockaddr_in_union addr = {};
 	uint64_t id;
 

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -698,12 +698,7 @@ int homa_ioc_recv(struct sock *sk, unsigned long arg) {
 	if ((args.message_buf && args.iovec)
 		|| (args.flags & ~HOMA_RECV_VALID_FLAGS)
 		|| args._pad[0]
-		|| args._pad[1]
-		|| args._pad[2]
-		|| args._pad[3]
-		|| args._pad[4]
-		|| args._pad[5]
-		|| args._pad[6]) {
+		|| args._pad[1]) {
 		return -EINVAL;
 	}
 	tt_record3("homa_ioc_recv starting, port %d, pid %d, flags %d",
@@ -850,12 +845,7 @@ int homa_ioc_reply(struct sock *sk, unsigned long arg) {
 	if ((args.message_buf && args.iovec)
 		|| (args.flags & ~HOMA_REPLY_VALID_FLAGS)
 		|| args._pad[0]
-		|| args._pad[1]
-		|| args._pad[2]
-		|| args._pad[3]
-		|| args._pad[4]
-		|| args._pad[5]
-		|| args._pad[6]) {
+		|| args._pad[1]) {
 		return -EINVAL;
 	}
 	tt_record3("homa_ioc_reply starting, id %llu, port %d, pid %d",
@@ -948,12 +938,7 @@ int homa_ioc_send(struct sock *sk, unsigned long arg) {
 	if ((args.message_buf && args.iovec)
 		|| (args.flags & ~HOMA_SEND_VALID_FLAGS)
 		|| args._pad[0]
-		|| args._pad[1]
-		|| args._pad[2]
-		|| args._pad[3]
-		|| args._pad[4]
-		|| args._pad[5]
-		|| args._pad[6]) {
+		|| args._pad[1]) {
 		return -EINVAL;
 	}
 //	err = audit_sockaddr(sizeof(args.dest_addr), &args.dest_addr);

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -698,7 +698,12 @@ int homa_ioc_recv(struct sock *sk, unsigned long arg) {
 	if ((args.message_buf && args.iovec)
 		|| (args.flags & ~HOMA_RECV_VALID_FLAGS)
 		|| args._pad[0]
-		|| args._pad[1]) {
+		|| args._pad[1]
+		|| args._pad[2]
+		|| args._pad[3]
+		|| args._pad[4]
+		|| args._pad[5]
+		|| args._pad[6]) {
 		return -EINVAL;
 	}
 	tt_record3("homa_ioc_recv starting, port %d, pid %d, flags %d",
@@ -845,7 +850,12 @@ int homa_ioc_reply(struct sock *sk, unsigned long arg) {
 	if ((args.message_buf && args.iovec)
 		|| (args.flags & ~HOMA_REPLY_VALID_FLAGS)
 		|| args._pad[0]
-		|| args._pad[1]) {
+		|| args._pad[1]
+		|| args._pad[2]
+		|| args._pad[3]
+		|| args._pad[4]
+		|| args._pad[5]
+		|| args._pad[6]) {
 		return -EINVAL;
 	}
 	tt_record3("homa_ioc_reply starting, id %llu, port %d, pid %d",
@@ -938,7 +948,12 @@ int homa_ioc_send(struct sock *sk, unsigned long arg) {
 	if ((args.message_buf && args.iovec)
 		|| (args.flags & ~HOMA_SEND_VALID_FLAGS)
 		|| args._pad[0]
-		|| args._pad[1]) {
+		|| args._pad[1]
+		|| args._pad[2]
+		|| args._pad[3]
+		|| args._pad[4]
+		|| args._pad[5]
+		|| args._pad[6]) {
 		return -EINVAL;
 	}
 //	err = audit_sockaddr(sizeof(args.dest_addr), &args.dest_addr);

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -692,6 +692,17 @@ int homa_ioc_recv(struct sock *sk, unsigned long arg) {
 
 	if (unlikely(copy_from_user(&args, (void *) arg, sizeof(args))))
 		return -EFAULT;
+	if ((args.message_buf && args.iovec)
+		|| (args.flags & ~HOMA_RECV_VALID_FLAGS)
+		|| args._pad[0]
+		|| args._pad[1]
+		|| args._pad[2]
+		|| args._pad[3]
+		|| args._pad[4]
+		|| args._pad[5]
+		|| args._pad[6]) {
+		return -EINVAL;
+	}
 	tt_record3("homa_ioc_recv starting, port %d, pid %d, flags %d",
 			hsk->port, current->pid, args.flags);
 	if (args.message_buf != NULL) {
@@ -832,6 +843,17 @@ int homa_ioc_reply(struct sock *sk, unsigned long arg) {
 		err = -EFAULT;
 		goto done;
 	}
+	if ((args.message_buf && args.iovec)
+		|| (args.flags & ~HOMA_REPLY_VALID_FLAGS)
+		|| args._pad[0]
+		|| args._pad[1]
+		|| args._pad[2]
+		|| args._pad[3]
+		|| args._pad[4]
+		|| args._pad[5]
+		|| args._pad[6]) {
+		return -EINVAL;
+	}
 	tt_record3("homa_ioc_reply starting, id %llu, port %d, pid %d",
 			args.id, hsk->port, current->pid);
 //	err = audit_sockaddr(sizeof(args.dest_addr), &args.dest_addr);
@@ -918,6 +940,17 @@ int homa_ioc_send(struct sock *sk, unsigned long arg) {
 		err = -EFAULT;
 		goto error;
 	}
+	if ((args.message_buf && args.iovec)
+		|| (args.flags & ~HOMA_SEND_VALID_FLAGS)
+		|| args._pad[0]
+		|| args._pad[1]
+		|| args._pad[2]
+		|| args._pad[3]
+		|| args._pad[4]
+		|| args._pad[5]
+		|| args._pad[6]) {
+		return -EINVAL;
+	}
 //	err = audit_sockaddr(sizeof(args.dest_addr), &args.dest_addr);
 //	if (unlikely(err))
 //		return err;
@@ -993,6 +1026,9 @@ int homa_ioc_abort(struct sock *sk, unsigned long arg) {
 	if (unlikely(copy_from_user(&args, (void *) arg, sizeof(args))))
 		return -EFAULT;
 
+	if (args._pad1 || args._pad2[0] || args._pad2[1]) {
+		return -EINVAL;
+	}
 	if (args.id == 0) {
 		homa_abort_sock_rpcs(hsk, -args.error);
 		return 0;

--- a/test/unit_homa_plumbing.c
+++ b/test/unit_homa_plumbing.c
@@ -368,6 +368,7 @@ TEST_F(homa_plumbing, homa_ioc_reply__dont_free_rpc)
 		        self->server_id, 2000, 100);
 	unit_log_clear();
 	self->reply_args.length = 10000;
+	self->reply_args.iovec = NULL;
 	self->reply_args.message_buf = (void *) 1000;
 	self->homa.rtt_bytes = 5000;
 	EXPECT_EQ(0, -homa_ioc_reply(&self->hsk.inet.sk,


### PR DESCRIPTION
Addressing incorrect usage and benchmarking API concerns.

Strictly check that user code is not filing in pad or flag fields with unknown values.

Modulate the size of the ioctl structs from 80/88 to 128 bytes, and benchmark.

This on my machines shows 128 byte ioctl structs are 1.8% faster than 80/88 byte structs, probably due to optimized memcpy.