### PR TITLE
Fix typo in ip6_as_be32, remove unnecessary blank line.

### DIFF
--- a/homa_impl.h
+++ b/homa_impl.h
@@ -2962,7 +2962,7 @@ static inline __be32 ip6_as_be32(const struct in6_addr x)
 	if (is_mapped_ipv4(x)) {
 		return x.in6_u.u6_addr32[3];
 	} else {
-		return x.in6_u.u6_addr32[3];
+		return x.in6_u.u6_addr32[1];
 	}
 }
 

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -771,7 +771,6 @@ int homa_ioc_recv(struct sock *sk, unsigned long arg) {
 	} else {
 		args.source_addr.in4.sin_family = AF_INET;
 		args.source_addr.in4.sin_port = htons(rpc->dport);
-
 		args.source_addr.in4.sin_addr.s_addr =
 			ip6_as_be32(rpc->peer->addr);
 	}


### PR DESCRIPTION
These were comments I made on the previous pull request that didn't make it into the version that was merged.