### PR TITLE
test_utils.cc: add missing include of sched.h

### DIFF
--- a/util/test_utils.cc
+++ b/util/test_utils.cc
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <arpa/inet.h>
+#include <sched.h>
 
 #include <algorithm>
 #include <atomic>


### PR DESCRIPTION
Without this change, build fails with
```
test_utils.cc: In function ‘void pin_thread(int)’:
test_utils.cc:176:9: error: ‘cpu_set_t’ was not declared in this scope
  176 |         cpu_set_t cpuset;
      |         ^~~~~~~~~
test_utils.cc:178:19: error: ‘cpuset’ was not declared in this scope
  178 |         CPU_ZERO(&cpuset);
      |                   ^~~~~~
test_utils.cc:178:9: error: ‘CPU_ZERO’ was not declared in this scope
  178 |         CPU_ZERO(&cpuset);
      |         ^~~~~~~~
test_utils.cc:179:9: error: ‘CPU_SET’ was not declared in this scope
  179 |         CPU_SET(core, &cpuset);
      |         ^~~~~~~
test_utils.cc:180:13: error: ‘sched_setaffinity’ was not declared in this scope
  180 |         if (sched_setaffinity(0, sizeof(cpuset), &cpuset) != 0)
      |             ^~~~~~~~~~~~~~~~~

```