### PR TITLE
Add gso_force_software kernel parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repo contains an implementation of the Homa transport protocol as a Linux k
   managed by the CloudLab project; it's in `cloudlab/bin/config`. I normally
   invoke it with no parameters to install and configure Homa on the current
   machine.
-  
+
 - The script `cloudlab/bin/install` will copy relevant Homa files
   across a cluster of machines and configure Homa on each node. It assumes
   that nodes have names `nodeN` where N is a small integer, and it also
@@ -78,8 +78,10 @@ This repo contains an implementation of the Homa transport protocol as a Linux k
   in software, but that's quite a bit slower. If for some reason software
   GSO doesn't work (it's fairly new in Homa), then messages larger than the
   maximum packet size may hang or result in very poor performance. If this
-  happens, you'll need to use `sysctl` to ensure that `max_gso_size` is the
-  same as the maximum packet size.
+  happens, you'll need to use `sysctl` to either enable force software GSO with
+  `gso_force_software` which is a bit slow but still uses GSO or ensure
+  that `max_gso_size` is the same as the maximum packet size which stops GSO
+  at all.
 
 - A collection of man pages is available in the "man" subdirectory. The API for
   Homa is different from TCP sockets.

--- a/homa_impl.h
+++ b/homa_impl.h
@@ -1893,6 +1893,13 @@ struct homa {
 	int max_gro_skbs;
 
 	/**
+	 * @gso_force_software: A value of non-zero will enable force software
+	 * GSO. Homa will force software GSO with this parameter enabled. Set
+	 * externally via sysctl.
+	 */
+	int gso_force_software;
+
+	/**
 	 * @gro_policy: An OR'ed together collection of bits that determine
 	 * how Homa packets should be steered for SoftIRQ handling.  A value
 	 * of zero will eliminate any Homa-specific behaviors, reverting

--- a/homa_plumbing.c
+++ b/homa_plumbing.c
@@ -271,6 +271,13 @@ static struct ctl_table homa_ctl_table[] = {
 		.proc_handler	= homa_dointvec
 	},
 	{
+		.procname	= "gso_force_software",
+		.data		= &homa_data.gso_force_software,
+		.maxlen		= sizeof(int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec
+	},
+	{
 		.procname	= "gro_busy_us",
 		.data		= &homa_data.gro_busy_usecs,
 		.maxlen		= sizeof(int),

--- a/homa_utils.c
+++ b/homa_utils.c
@@ -145,6 +145,7 @@ int homa_init(struct homa *homa)
 	homa->verbose = 0;
 	homa->max_gso_size = 10000;
 	homa->max_gro_skbs = 20;
+	homa->gso_force_software = 0;
 	homa->gro_policy = HOMA_GRO_NORMAL;
 	homa->gro_busy_usecs = 10;
 	homa->timer_ticks = 0;

--- a/man/homa.7
+++ b/man/homa.7
@@ -321,6 +321,14 @@ of the bandwidth is for FIFO and 90% for SRPT). As of October 2020, a small
 value can provide significant benefits for the largest messages under very high
 loads, but for most loads its effect is negligible.
 .TP
+.IR gso_force_software
+An integer value that determines whether to force software GSO when sending
+packets. Nonzero means forcing sofotware GSO, helpful for making Homa work
+with GSO on virtio or Intel NiCs. If you don't care about GSO, please refer
+to "NIC support for TSO" section in README.md instead of setting this
+parameter. Also see code in homa_outgoing.c and comments in notes.txt,
+perf.txt with keyword "software GSO" for more details.
+.TP
 .IR gro_policy
 An integer value that determines how Homa processes incoming packets
 at the GRO level. See code in homa_offload.c for more details.


### PR DESCRIPTION
Add `gso_force_software` kernel parameter which can force software GSO when set nonzero through `sysctl`. This parameter also indicates an alternative way to make Homa work over TSO-unsupported NICs instead of setting `max_gso_size`.

The `.pcap` files in [force-software-GSO.zip](https://github.com/PlatformLab/HomaModule/files/10913738/force-software-GSO.zip) are my experiment results over two virtual machines and one host setup. Virtual machines are installed with libvirt and with virtio NICs. The `node0` is inserted the HomaModule while `node1` is not as `tcpdump` doesn't work with HomaModule's GRO bypass techniques. These `.pcap` files show we need explicitly assign `skb_shinfo(skb)->gso_type = 0xd` while creating skbs to make the sender perform the segmentation in a expected way.

