### PR TITLE
Fix `vlan` IP RegEx

### DIFF
--- a/cloudlab/bin/config
+++ b/cloudlab/bin/config
@@ -91,7 +91,7 @@ def get_interfaces():
             if match:
                 interface = match.group(1)
             continue
-        if re.match('^[ ]+ inet 10\.0\.1\.', line):
+        if re.match('^[ ]+ inet 10\.10\.1\.', line):
             vlan = current
     if not vlan or not interface:
         print("Found the following interfaces: %s" % (available))


### PR DESCRIPTION
CloudLab's `xl170` machines have an interface `ens1f1np1` with the IPs in the range 10.10.1.0/24 (as seen in the image below), but the Regular Expression in `cloudlab/bin/config` script checks for `^[ ]+ inet 10\.0\.1\.` rather than `^[ ]+ inet 10\.10\.1\.`. This PR is to correct that, as the existing script cannot assign the `vlan` value and causes the script to error out.



![image](https://user-images.githubusercontent.com/50140864/236550346-d0aab06b-61d2-421e-9b99-8520283208d0.png)