### PR TITLE
Switch from `cpupower` to `cpufrequtils` to set Scaling Governors

### DIFF
--- a/cloudlab/bin/config
+++ b/cloudlab/bin/config
@@ -294,8 +294,12 @@ def config_power():
         # C-states are disabled, then so is Turbo mode, and that will hurt
         # peak peformance.
         print("Configuring power settings for Intel CPUs")
-        subprocess.run(["sudo", "cpupower", "frequency-set", "-g",
-                "performance"], check=True)
+        subprocess.run(["sudo", "apt-get", "install", "-y", "cpufrequtils"],
+                check=True)
+        read_cpu_info()
+        for num in range(len(cpu_info)):
+            subprocess.run(["sudo", "cpufreq-set", "-c", "%d" % (num), "-g",
+                    "performance"], check=True)
     elif (type == "c6525-100g") or (type == "c6525-25g"):
         # AMD 7402P (EPYC Rome processor); don't know of any appropriate
         # power setting changes


### PR DESCRIPTION
### Machine Specs

- OS: Ubuntu 22.04.2 LTS (`jammy`)
- Linux kernel: `Linux 5.18.0-051800-generic x86_64`
- Testbed: [CloudLab](https://cloudlab.us)'s `xl170` machines

### Problem and Remedy

`cpupower` was not available on the machine (and I think it doesn't exist in the newer installations of Ubuntu) and so the `cloudlab/bin/config` script was erroring out. [After some searching, I found the `cpufrequtils` command](https://askubuntu.com/questions/20271/how-do-i-set-the-cpu-frequency-scaling-governor-for-all-cores-at-once), so I implemented that. I have not checked whether `cpufrequtils` is available on all Ubuntu installations though.
