### PR TITLE
Dist to proto

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -2,9 +2,9 @@
 
 CFLAGS := -Wall -Werror -fno-strict-aliasing -O3 -I..
 
-BINS := buffer_client buffer_server cp_node dist_test get_time_trace \
-	homa_prio homa_test receive_raw scratch send_raw server \
-        smi test_time_trace use_memory
+BINS := buffer_client buffer_server cp_node dist_test dist_to_proto \
+	get_time_trace homa_prio homa_test receive_raw scratch send_raw \
+        server smi test_time_trace use_memory
 
 OBJS := $(patsubst %,%.o,$(BINS))
 

--- a/util/dist.cc
+++ b/util/dist.cc
@@ -205,6 +205,21 @@ std::vector<int> dist_point_gen::values() const
 	return output;
 }
 
+/**
+ * CDF_fractions() - Returns a vector containing the cdf fraction of
+ * every point in this distribution.
+ */
+std::vector<double> dist_point_gen::CDF_fractions() const
+{
+	std::vector<double> output;
+	output.reserve(dist_points.size());
+
+	for (const cdf_point &point: dist_points) {
+		output.push_back(point.fraction);
+	}
+	return output;
+}
+
 /*
  * The following arrays store CDFs for Workloads 1-5 from the Homa
  * SIGCOMM paper.

--- a/util/dist.h
+++ b/util/dist.h
@@ -35,6 +35,7 @@ class dist_point_gen {
 	double get_mean() const {return dist_mean;}
 	double dist_overhead(int mtu) const;
 	std::vector<int> values() const;
+	std::vector<double> CDF_fractions() const;
 
 	/**
 	 * struct dist_point - Describes one point in a CDF of message lengths.

--- a/util/dist_to_proto.cc
+++ b/util/dist_to_proto.cc
@@ -1,0 +1,55 @@
+#include "dist.h"
+#include "homa.h"
+#include "iostream"
+
+/**
+ * This program takes one of the five workload distributions and converts
+ * it into a fragment of a textformat protobuf used in distbench. It will first
+ * merge buckets and truncate cdf_point sizes according to command line arguments
+ * then write the cdf_points to stdout and the interval conversion to stderr
+ * 
+ * Usage:
+ * ./dist_to_proto workload [max message length] [min bucket frac]
+ * [max size ratio] [gigabits per second]
+ */
+int main (int argc, char**argv)
+{
+  int max_message_length = HOMA_MAX_MESSAGE_LENGTH;
+  double min_bucket_frac = 0.0025;
+  double max_size_ratio = 1.2;
+  double gbps = 20.0;
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s workload [max message length] [min bucket frac]"
+            " [max size ratio] [gbps]\n", argv[0]);
+    exit(1);
+  }
+  if (argc > 2) {
+    max_message_length = atoi(argv[2]);
+  }
+  if (argc > 3) {
+    min_bucket_frac = std::stod(argv[3]);
+  }
+  if (argc > 4) {
+    max_size_ratio = std::stod(argv[4]);
+  }
+  if (argc > 5) {
+    gbps = std::stod(argv[5]);
+  }
+
+  dist_point_gen generator(argv[1], max_message_length,
+                           min_bucket_frac, max_size_ratio);
+  std::vector<int> values = generator.values();
+  std::vector<double> fractions = generator.CDF_fractions();
+
+  for (size_t i = 0; i < values.size(); ++i) {
+    printf("    cdf_points { value: %d, cdf: %20.19f }\n", values[i], fractions[i]);
+  }
+
+  /**
+   * Convert average size to bits, then divide by gbps and round up to get
+   * nanoseconds, then multiply by 2 because request size and response
+   * size are equal
+   */
+  double interval_ns = (std::ceil( (generator.get_mean() * 8.0) / gbps)) * 2;
+  fprintf(stderr,"%.0f", interval_ns);
+}


### PR DESCRIPTION
This branch adds code to HomaModule to produce text proto files from the workload distributions in HomaModule/util/dist.cc that can be used in Distbench. Generate_configs.sh invokes dist_to_proto.sh for all 5 workloads and calls dist_to_proto.cc which writes out the cdf points and converts Gbps to us.