### PR TITLE
Use ECONNRESET for homa_copy_to_user if recvmsg called with id 0

### DIFF
--- a/homa_incoming.c
+++ b/homa_incoming.c
@@ -1343,8 +1343,11 @@ found_rpc:
 			}
 			if (!rpc->error)
 				rpc->error = homa_copy_to_user(rpc);
-			if (rpc->error)
+			if (rpc->error) {
+				if (id == 0)
+					rpc->error = -ECONNRESET;
 				goto done;
+			}
 			atomic_andnot(RPC_PKTS_READY, &rpc->flags);
 			if ((rpc->msgin.bytes_remaining == 0)
 					&& (!skb_queue_len(&rpc->msgin.packets)))

--- a/man/recvmsg.2
+++ b/man/recvmsg.2
@@ -274,6 +274,10 @@ or
 .I sockfd
 was not a Homa socket.
 .TP
+.B ECONNRESET
+Any RPC is interested but the RPC selected internally is aborted while being
+copied.
+.TP
 .B ENOMEM
 Memory could not be allocated for internal data structures needed
 for the message, or space in the application-supplied buffer pool


### PR DESCRIPTION
Since the `recvmsg` is indeed valid under this case, returning `EINVAL` can be confusing, I think it would be better to use another error number to indicate this situation, I chose ECONNRESET for this case, maybe you have a better idea?