### PR TITLE
Added missing SPLIT_64

### DIFF
--- a/homa_impl.h
+++ b/homa_impl.h
@@ -156,6 +156,7 @@ extern struct homa_numa *homa_numas[];
 extern int homa_num_numas;
 
 #define sizeof32(type) ((int) (sizeof(type)))
+#define SPLIT_64(num) ((uint64_t) (num) >> 32), ((uint64_t) (num) & 0xffffffff)
 
 /** define CACHE_LINE_SIZE - The number of bytes in a cache line. */
 #define CACHE_LINE_SIZE 64


### PR DESCRIPTION
Current code generates a build error. homa_offload.c contains a reference to SPLIT_64 that is not defined anywhere. This pull request adds the missing definition to homa_impl.h.

