### PR TITLE
Fix invalid access to shinfo->frags[-1] when nr_frags is 0

### DIFF
--- a/homa_skb.c
+++ b/homa_skb.c
@@ -193,7 +193,6 @@ void *homa_skb_extend_frags(struct homa *homa, struct sk_buff *skb, int *length)
 
 	/* Can we just extend the skb's last fragment? */
 	skb_core = &per_cpu(homa_skb_core, raw_smp_processor_id());
-	frag = &shinfo->frags[shinfo->nr_frags - 1];
 	if (shinfo->nr_frags > 0) {
 		frag = &shinfo->frags[shinfo->nr_frags - 1];
 		if (skb_frag_page(frag) == skb_core->skb_page &&

--- a/homa_skb.c
+++ b/homa_skb.c
@@ -194,21 +194,24 @@ void *homa_skb_extend_frags(struct homa *homa, struct sk_buff *skb, int *length)
 	/* Can we just extend the skb's last fragment? */
 	skb_core = &per_cpu(homa_skb_core, raw_smp_processor_id());
 	frag = &shinfo->frags[shinfo->nr_frags - 1];
-	if (shinfo->nr_frags > 0 &&
-	    skb_frag_page(frag) == skb_core->skb_page &&
-	    skb_core->page_inuse < skb_core->page_size &&
-	    (frag->offset + skb_frag_size(frag)) == skb_core->page_inuse) {
-		if ((skb_core->page_size - skb_core->page_inuse) <
-		     actual_size)
-			actual_size = skb_core->page_size -
-					skb_core->page_inuse;
-		*length = actual_size;
-		skb_frag_size_add(frag, actual_size);
-		result = page_address(skb_frag_page(frag)) +
-				skb_core->page_inuse;
-		skb_core->page_inuse += actual_size;
-		skb_len_add(skb, actual_size);
-		return result;
+	if (shinfo->nr_frags > 0) {
+		frag = &shinfo->frags[shinfo->nr_frags - 1];
+		if (skb_frag_page(frag) == skb_core->skb_page &&
+		    skb_core->page_inuse < skb_core->page_size &&
+		    (frag->offset + skb_frag_size(frag)) ==
+			    skb_core->page_inuse) {
+			if ((skb_core->page_size - skb_core->page_inuse) <
+			    actual_size)
+				actual_size = skb_core->page_size -
+					      skb_core->page_inuse;
+			*length = actual_size;
+			skb_frag_size_add(frag, actual_size);
+			result = page_address(skb_frag_page(frag)) +
+				 skb_core->page_inuse;
+			skb_core->page_inuse += actual_size;
+			skb_len_add(skb, actual_size);
+			return result;
+		}
 	}
 
 	/* Need to add a new fragment to the skb. */


### PR DESCRIPTION
My kernel (`CONFIG_UBSAN=1`) complains about access to -1 index to frags.
```
[  +9.113160] ------------[ cut here ]------------
[  +0.000006] UBSAN: array-index-out-of-bounds in /home/breakertt/HomaModule/homa_skb.c:196:23
[  +0.000701] index -1 is out of range for type 'skb_frag_t [17]'
[  +0.000478] CPU: 1 PID: 3115 Comm: simple_client Tainted: G           OE      6.10.10-061010-generic #202409121037
[  +0.000003] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.15.0-1 04/01/2014
[  +0.000002] Call Trace:
[  +0.000002]  <TASK>
[  +0.000004]  show_stack+0x49/0x60
[  +0.000007]  dump_stack_lvl+0x5f/0x90
[  +0.000008]  dump_stack+0x10/0x18
[  +0.000003]  ubsan_epilogue+0x9/0x40
[  +0.000003]  __ubsan_handle_out_of_bounds.cold+0x44/0x49
[  +0.000004]  homa_skb_extend_frags+0x22e/0x280 [homa]
[  +0.000007]  ? __entry_text_end+0x102589/0x10258d
[  +0.000004]  homa_skb_append_from_iter+0x7f/0xe0 [homa]
[  +0.000013]  homa_new_data_packet+0x24e/0x260 [homa]
[  +0.000008]  homa_message_out_fill+0x290/0x4c0 [homa]
[  +0.000006]  homa_sendmsg+0x241/0x700 [homa]
[  +0.000005]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? aa_sk_perm+0x46/0x230
[  +0.000012]  inet_sendmsg+0x7d/0x80
[  +0.000003]  ? inet_sendmsg+0x7d/0x80
[  +0.000003]  ____sys_sendmsg+0x32e/0x3f0
[  +0.000005]  ___sys_sendmsg+0x9a/0xf0
[  +0.000008]  __sys_sendmsg+0xe5/0x120
[  +0.000005]  __x64_sys_sendmsg+0x1d/0x30
[  +0.000003]  x64_sys_call+0x6ad/0x2280
[  +0.000004]  do_syscall_64+0x7e/0x170
[  +0.000004]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? __mod_lruvec_state+0x36/0x50
[  +0.000004]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000005]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? xas_find+0x6f/0x1d0
[  +0.000003]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? next_uptodate_folio+0xaa/0x370
[  +0.000004]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? _raw_spin_unlock+0xe/0x40
[  +0.000002]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? filemap_map_pages+0x34f/0x570
[  +0.000005]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? do_read_fault+0xfd/0x1d0
[  +0.000004]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000001]  ? do_fault+0x1ae/0x300
[  +0.000003]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? handle_pte_fault+0x12a/0x1c0
[  +0.000003]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? __handle_mm_fault+0x3d5/0x7b0
[  +0.000005]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000001]  ? __count_memcg_events+0x86/0x160
[  +0.000004]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000001]  ? count_memcg_events.constprop.0+0x2a/0x50
[  +0.000003]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000001]  ? handle_mm_fault+0x1f8/0x310
[  +0.000004]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? do_user_addr_fault+0x18b/0x660
[  +0.000003]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? irqentry_exit_to_user_mode+0x73/0x260
[  +0.000003]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000002]  ? irqentry_exit+0x43/0x50
[  +0.000002]  ? srso_alias_return_thunk+0x5/0xfbef5
[  +0.000009]  ? exc_page_fault+0x96/0x1c0
[  +0.000002]  entry_SYSCALL_64_after_hwframe+0x76/0x7e
[  +0.000003] RIP: 0033:0x761a24b2c004
[  +0.000014] Code: 15 19 6e 0d 00 f7 d8 64 89 02 b8 ff ff ff ff eb bf 0f 1f 44 00 00 f3 0f 1e fa 80 3d 45 f0 0d 00 00 74 13 b8 2e 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 4c c3 0f 1f 00 55 48 89 e5 48 83 ec 20 89 55
[  +0.000002] RSP: 002b:00007ffdd7b01438 EFLAGS: 00000202 ORIG_RAX: 000000000000002e
[  +0.000004] RAX: ffffffffffffffda RBX: 00007ffdd7b01888 RCX: 0000761a24b2c004
[  +0.000001] RDX: 0000000000000000 RSI: 00007ffdd7b014a0 RDI: 0000000000000003
[  +0.000002] RBP: 00007ffdd7b014e0 R08: 0000000000000010 R09: 00005eb522e9d340
[  +0.000002] R10: 0000000000000000 R11: 0000000000000202 R12: 000000000000000a
[  +0.000001] R13: 0000000000000000 R14: 00005eb522e9cc00 R15: 0000761a24e54000
[  +0.000004]  </TASK>
[  +0.000015] ---[ end trace ]---
```