### PR TITLE
add headerfile for tcp_v6_check use

### DIFF
--- a/homa_hijack.h
+++ b/homa_hijack.h
@@ -25,6 +25,7 @@
 #include "homa_peer.h"
 #include "homa_sock.h"
 #include "homa_wire.h"
+#include <net/ip6_checksum.h>
 
 /* Special value stored in the flags field of TCP headers to indicate that
  * the packet is actually a Homa packet. It includes the SYN and RST flags


### PR DESCRIPTION
Hello John,

I added a header file to solve below compilation error.
````
  CC [M]  /home/dc-user/homa/HomaModule/homa_outgoing.o
In file included from /home/dc-user/homa/HomaModule/homa_outgoing.c:13:
/home/dc-user/homa/HomaModule/homa_hijack.h: In function ‘homa_hijack_set_hdr’:
/home/dc-user/homa/HomaModule/homa_hijack.h:68:18: error: implicit declaration of function ‘tcp_v6_check’; did you mean ‘tcp_v4_check’? [-Werror=implicit-function-declaration]
   h->checksum = ~tcp_v6_check(skb->len, &peer->flow.u.ip6.saddr,
                  ^~~~~~~~~~~~
                  tcp_v4_check
cc1: some warnings being treated as errors
````

Thanks